### PR TITLE
Proof Of Concept: adding Brotli/gzip/etc.. encoding capabilities to the zig sdk

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+**Please do not submit any pull requests here – they will be closed!**
+
+This repository is a read-only subset of the Datastar monorepo. Please open your pull request there instead:
+https://github.com/starfederation/datastar

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Run `zig build test`.
 
 ## Usage
 
+Install with `zig fetch --save git+https://github.com/starfederation/datastar-zig`
+
 ```zig
 const datastar = @import("datastar");
 
@@ -20,3 +22,5 @@ try sse.mergeFragments("<div id='question'>What do you put in a toaster?</div>",
 // Merges signals into the signals.
 try sse.mergeSignals("{response: '', answer: 'bread'}", .{});
 ```
+
+Full examples at https://github.com/starfederation/datastar/tree/main/examples/zig

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Run `zig build test`.
 
 ## Usage
 
-Install with `zig fetch --save git+https://github.com/starfederation/datastar-zig`
-
 ```zig
 const datastar = @import("datastar");
 
@@ -22,5 +20,3 @@ try sse.mergeFragments("<div id='question'>What do you put in a toaster?</div>",
 // Merges signals into the signals.
 try sse.mergeSignals("{response: '', answer: 'bread'}", .{});
 ```
-
-Full examples at https://github.com/starfederation/datastar/tree/main/examples/zig

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ try sse.mergeFragments("<div id='question'>What do you put in a toaster?</div>",
 try sse.mergeSignals("{response: '', answer: 'bread'}", .{});
 ```
 
-Full examples at https://github.com/starfederation/datastar/tree/develop/examples/zig
+Full examples at https://github.com/starfederation/datastar/tree/main/examples/zig

--- a/README.md
+++ b/README.md
@@ -8,16 +8,7 @@ Run `zig build test`.
 
 ## Usage
 
-Install datastar
-
-```shell
-$ mkdir my_project
-$ cd my_project
-$ zig init
-$ zig fetch --save git+https://github.com/starfederation/datastar-zig`
-```
-
-then
+Install with `zig fetch --save git+https://github.com/starfederation/datastar-zig`
 
 ```zig
 const datastar = @import("datastar");
@@ -31,3 +22,5 @@ try sse.mergeFragments("<div id='question'>What do you put in a toaster?</div>",
 // Merges signals into the signals.
 try sse.mergeSignals("{response: '', answer: 'bread'}", .{});
 ```
+
+Full examples at https://github.com/starfederation/datastar/tree/develop/examples/zig

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ Run `zig build test`.
 
 ## Usage
 
+Install datastar
+
+```shell
+$ mkdir my_project
+$ cd my_project
+$ zig init
+$ zig fetch --save git+https://github.com/starfederation/datastar-zig`
+```
+
+then
+
 ```zig
 const datastar = @import("datastar");
 

--- a/build.zig
+++ b/build.zig
@@ -3,10 +3,40 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    _ = target;
-    _ = optimize;
+    const dep_opts = .{ .target = target, .optimize = optimize };
+
+    const httpz = b.dependency("httpz", dep_opts).module("httpz");
+    const tokamak = b.dependency("tokamak", dep_opts).module("tokamak");
+
     const datastar = b.addModule("datastar", .{
         .root_source_file = b.path("src/root.zig"),
+        .imports = &.{
+            .{ .name = "httpz", .module = httpz },
+            .{ .name = "tokamak", .module = tokamak },
+        },
     });
-    _ = datastar;
+
+    const options = b.addOptions();
+    options.addOption(bool, "http1", true);
+
+    datastar.addOptions("config", options);
+
+    const tests = b.addTest(.{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+        .test_runner = .{
+            .path = b.path("test_runner.zig"),
+            .mode = .simple,
+        },
+    });
+
+    tests.root_module.addImport("httpz", httpz);
+    tests.root_module.addImport("tokamak", tokamak);
+
+    const run_test = b.addRunArtifact(tests);
+    run_test.has_side_effects = true;
+
+    const test_step = b.step("test", "Run tests");
+    test_step.dependOn(&run_test.step);
 }

--- a/build.zig
+++ b/build.zig
@@ -7,12 +7,14 @@ pub fn build(b: *std.Build) void {
 
     const httpz = b.dependency("httpz", dep_opts).module("httpz");
     const tokamak = b.dependency("tokamak", dep_opts).module("tokamak");
+    const brotli = b.dependency("zig-brotli", dep_opts).module("brotli");
 
     const datastar = b.addModule("datastar", .{
         .root_source_file = b.path("src/root.zig"),
         .imports = &.{
             .{ .name = "httpz", .module = httpz },
             .{ .name = "tokamak", .module = tokamak },
+            .{ .name = "brotli", .module = brotli },
         },
     });
 
@@ -33,6 +35,7 @@ pub fn build(b: *std.Build) void {
 
     tests.root_module.addImport("httpz", httpz);
     tests.root_module.addImport("tokamak", tokamak);
+    tests.root_module.addImport("brotli", brotli);
 
     const run_test = b.addRunArtifact(tests);
     run_test.has_side_effects = true;

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,16 @@
 .{
     .name = "datastar",
-    .version = "0.0.0",
-    .dependencies = .{},
+    .version = "1.0.0-beta.1",
+    .dependencies = .{
+        .httpz = .{
+            .url = "git+https://github.com/karlseguin/http.zig?ref=master#a691d731047e9a5a79d71ac594cb8f5fad1d0705",
+            .hash = "122072c92285c8c44055eb45058b834d1e7ecd46a5704d58a207103c39fb5922b8f5",
+        },
+        .tokamak = .{
+            .url = "git+https://github.com/cztomsik/tokamak#857fa78a6fc77c4effa235ef049b8a6461120e5d",
+            .hash = "1220ddbe12aa69b3293f0abd7078ff93c309b4f4383e18cbe24b163e4ee4b2befa49",
+        },
+    },
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "datastar",
+    .name = .datastar,
+    .fingerprint = 0xc03ca25beb98a054,
     .version = "1.0.0-beta.1",
     .dependencies = .{
         .httpz = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,6 +10,11 @@
             .url = "git+https://github.com/cztomsik/tokamak#857fa78a6fc77c4effa235ef049b8a6461120e5d",
             .hash = "1220ddbe12aa69b3293f0abd7078ff93c309b4f4383e18cbe24b163e4ee4b2befa49",
         },
+        // Add Brotli encoding capabilities
+        .@"zig-brotli" = .{
+            .url = "git+https://github.com/0x546F6D/zig-brotli#bf3158050277628148f8d63f54677fba5c9560cd",
+            .hash = "12202d0830b3ebf2c90069c8f60f5ff7121c05bd70c376ec376f6082ad5909471ce3",
+        },
     },
     .paths = .{
         "build.zig",

--- a/src/ServerSentEventGenerator.zig
+++ b/src/ServerSentEventGenerator.zig
@@ -96,7 +96,9 @@ fn send(
         try self.writer.print("id: {s}\n", .{id});
     }
 
-    try self.writer.print("retry: {d}\n", .{options.retry_duration});
+    if (options.retry_duration != consts.default_sse_retry_duration) {
+        try self.writer.print("retry: {d}\n", .{options.retry_duration});
+    }
 
     for (data) |line| {
         try self.writer.print("data: {s}\n", .{line});
@@ -116,9 +118,10 @@ pub fn executeScript(
 ) !void {
     var data = std.ArrayList([]const u8).init(self.allocator);
 
-    if (!std.meta.eql(
-        default_execute_script_attributes,
-        options.attributes,
+    if (options.attributes.len != 1 or !std.mem.eql(
+        u8,
+        default_execute_script_attributes[0],
+        options.attributes[0],
     )) {
         for (options.attributes) |attribute| {
             const line = try std.fmt.allocPrint(

--- a/src/ServerSentEventGenerator.zig
+++ b/src/ServerSentEventGenerator.zig
@@ -88,50 +88,6 @@ pub const RemoveSignalsOptions = struct {
     retry_duration: u32 = consts.default_sse_retry_duration,
 };
 
-fn prepareMsg(
-    self: *@This(),
-    event: consts.EventType,
-    data: []const []const u8,
-    options: struct {
-        event_id: ?[]const u8 = null,
-        retry_duration: u32 = consts.default_sse_retry_duration,
-    },
-) !void {
-    try self.sse_msg.append(try std.fmt.allocPrint(self.allocator, "event: {}\n", .{event}));
-
-    if (options.event_id) |id| {
-        try self.sse_msg.append(try std.fmt.allocPrint(self.allocator, "id: {s}\n", .{id}));
-    }
-
-    if (options.retry_duration != consts.default_sse_retry_duration) {
-        try self.sse_msg.append(try std.fmt.allocPrint(self.allocator, "retry: {d}\n", .{options.retry_duration}));
-    }
-
-    for (data) |line| {
-        try self.sse_msg.append(try std.fmt.allocPrint(self.allocator, "data: {s}\n", .{line}));
-    }
-    try self.sse_msg.append("\n\n");
-}
-
-pub fn sendMsg(
-    self: *@This(),
-) !void {
-    self.mutex.lock();
-    defer self.mutex.unlock();
-    const sse_msg = try std.mem.concat(self.allocator, u8, self.sse_msg.items);
-    switch (self.encoding) {
-        .none => try self.writer.writeAll(sse_msg),
-        .br => {
-            const encoded = try br.encode(self.allocator, sse_msg);
-            try self.writer.writeAll(encoded);
-        },
-        .gzip => {
-            var fbs = std.io.fixedBufferStream(sse_msg);
-            try std.compress.gzip.compress(fbs.reader(), self.writer, .{});
-        },
-    }
-}
-
 fn send(
     self: *@This(),
     event: consts.EventType,
@@ -158,6 +114,51 @@ fn send(
     }
 
     try self.writer.writeAll("\n\n");
+}
+
+fn prepareMsg(
+    self: *@This(),
+    event: consts.EventType,
+    data: []const []const u8,
+    options: struct {
+        event_id: ?[]const u8 = null,
+        retry_duration: u32 = consts.default_sse_retry_duration,
+    },
+) !void {
+    try self.sse_msg.append(try std.fmt.allocPrint(self.allocator, "event: {}\n", .{event}));
+
+    if (options.event_id) |id| {
+        try self.sse_msg.append(try std.fmt.allocPrint(self.allocator, "id: {s}\n", .{id}));
+    }
+
+    if (options.retry_duration != consts.default_sse_retry_duration) {
+        try self.sse_msg.append(try std.fmt.allocPrint(self.allocator, "retry: {d}\n", .{options.retry_duration}));
+    }
+
+    for (data) |line| {
+        try self.sse_msg.append(try std.fmt.allocPrint(self.allocator, "data: {s}\n", .{line}));
+    }
+    try self.sse_msg.append("\n\n");
+}
+
+/// Send encoded msg to the browser
+pub fn sendMsg(
+    self: *@This(),
+) !void {
+    self.mutex.lock();
+    defer self.mutex.unlock();
+    const sse_msg = try std.mem.concat(self.allocator, u8, self.sse_msg.items);
+    switch (self.encoding) {
+        .none => try self.writer.writeAll(sse_msg),
+        .br => {
+            const encoded = try br.encode(self.allocator, sse_msg);
+            try self.writer.writeAll(encoded);
+        },
+        .gzip => {
+            var fbs = std.io.fixedBufferStream(sse_msg);
+            try std.compress.gzip.compress(fbs.reader(), self.writer, .{});
+        },
+    }
 }
 
 /// `ExecuteScript` executes JavaScript in the browser

--- a/src/ServerSentEventGenerator.zig
+++ b/src/ServerSentEventGenerator.zig
@@ -1,11 +1,19 @@
 const std = @import("std");
 const consts = @import("consts.zig");
+const Brotli = @import("brotli");
+const br = Brotli.init(Brotli.Settings{});
 
 const default_execute_script_attributes: []const []const u8 = &[_][]const u8{consts.default_execute_script_attributes};
 
 allocator: std.mem.Allocator,
 writer: std.net.Stream.Writer,
 mutex: std.Thread.Mutex = .{},
+encoding: Encoding = .none,
+
+pub const Encoding = enum {
+    none,
+    br,
+};
 
 pub const ExecuteScriptOptions = struct {
     /// `event_id` can be used by the backend to replay events.
@@ -89,22 +97,42 @@ fn send(
 ) !void {
     self.mutex.lock();
     defer self.mutex.unlock();
+    if (self.encoding == .none) {
+        try self.writer.print("event: {}\n", .{event});
 
-    try self.writer.print("event: {}\n", .{event});
+        if (options.event_id) |id| {
+            try self.writer.print("id: {s}\n", .{id});
+        }
 
-    if (options.event_id) |id| {
-        try self.writer.print("id: {s}\n", .{id});
+        if (options.retry_duration != consts.default_sse_retry_duration) {
+            try self.writer.print("retry: {d}\n", .{options.retry_duration});
+        }
+
+        for (data) |line| {
+            try self.writer.print("data: {s}\n", .{line});
+        }
+
+        try self.writer.writeAll("\n\n");
+    } else {
+        var sse_msg = std.ArrayList([]const u8).init(self.allocator);
+        try sse_msg.append(try std.fmt.allocPrint(self.allocator, "event: {}\n", .{event}));
+
+        if (options.event_id) |id| {
+            try sse_msg.append(try std.fmt.allocPrint(self.allocator, "id: {s}\n", .{id}));
+        }
+
+        if (options.retry_duration != consts.default_sse_retry_duration) {
+            try sse_msg.append(try std.fmt.allocPrint(self.allocator, "retry: {d}\n", .{options.retry_duration}));
+        }
+
+        for (data) |line| {
+            try sse_msg.append(try std.fmt.allocPrint(self.allocator, "data: {s}\n", .{line}));
+        }
+        try sse_msg.append("\n\n");
+
+        const encoded = try br.encode(self.allocator, try std.mem.concat(self.allocator, u8, sse_msg.items));
+        try self.writer.writeAll(encoded);
     }
-
-    if (options.retry_duration != consts.default_sse_retry_duration) {
-        try self.writer.print("retry: {d}\n", .{options.retry_duration});
-    }
-
-    for (data) |line| {
-        try self.writer.print("data: {s}\n", .{line});
-    }
-
-    try self.writer.writeAll("\n\n");
 }
 
 /// `ExecuteScript` executes JavaScript in the browser

--- a/src/ServerSentEventGenerator.zig
+++ b/src/ServerSentEventGenerator.zig
@@ -9,10 +9,12 @@ allocator: std.mem.Allocator,
 writer: std.net.Stream.Writer,
 mutex: std.Thread.Mutex = .{},
 encoding: Encoding = .none,
+sse_msg: std.ArrayList([]const u8) = undefined,
 
 pub const Encoding = enum {
     none,
     br,
+    gzip,
 };
 
 pub const ExecuteScriptOptions = struct {
@@ -86,6 +88,50 @@ pub const RemoveSignalsOptions = struct {
     retry_duration: u32 = consts.default_sse_retry_duration,
 };
 
+fn prepareMsg(
+    self: *@This(),
+    event: consts.EventType,
+    data: []const []const u8,
+    options: struct {
+        event_id: ?[]const u8 = null,
+        retry_duration: u32 = consts.default_sse_retry_duration,
+    },
+) !void {
+    try self.sse_msg.append(try std.fmt.allocPrint(self.allocator, "event: {}\n", .{event}));
+
+    if (options.event_id) |id| {
+        try self.sse_msg.append(try std.fmt.allocPrint(self.allocator, "id: {s}\n", .{id}));
+    }
+
+    if (options.retry_duration != consts.default_sse_retry_duration) {
+        try self.sse_msg.append(try std.fmt.allocPrint(self.allocator, "retry: {d}\n", .{options.retry_duration}));
+    }
+
+    for (data) |line| {
+        try self.sse_msg.append(try std.fmt.allocPrint(self.allocator, "data: {s}\n", .{line}));
+    }
+    try self.sse_msg.append("\n\n");
+}
+
+pub fn sendMsg(
+    self: *@This(),
+) !void {
+    self.mutex.lock();
+    defer self.mutex.unlock();
+    const sse_msg = try std.mem.concat(self.allocator, u8, self.sse_msg.items);
+    switch (self.encoding) {
+        .none => try self.writer.writeAll(sse_msg),
+        .br => {
+            const encoded = try br.encode(self.allocator, sse_msg);
+            try self.writer.writeAll(encoded);
+        },
+        .gzip => {
+            var fbs = std.io.fixedBufferStream(sse_msg);
+            try std.compress.gzip.compress(fbs.reader(), self.writer, .{});
+        },
+    }
+}
+
 fn send(
     self: *@This(),
     event: consts.EventType,
@@ -97,42 +143,21 @@ fn send(
 ) !void {
     self.mutex.lock();
     defer self.mutex.unlock();
-    if (self.encoding == .none) {
-        try self.writer.print("event: {}\n", .{event});
+    try self.writer.print("event: {}\n", .{event});
 
-        if (options.event_id) |id| {
-            try self.writer.print("id: {s}\n", .{id});
-        }
-
-        if (options.retry_duration != consts.default_sse_retry_duration) {
-            try self.writer.print("retry: {d}\n", .{options.retry_duration});
-        }
-
-        for (data) |line| {
-            try self.writer.print("data: {s}\n", .{line});
-        }
-
-        try self.writer.writeAll("\n\n");
-    } else {
-        var sse_msg = std.ArrayList([]const u8).init(self.allocator);
-        try sse_msg.append(try std.fmt.allocPrint(self.allocator, "event: {}\n", .{event}));
-
-        if (options.event_id) |id| {
-            try sse_msg.append(try std.fmt.allocPrint(self.allocator, "id: {s}\n", .{id}));
-        }
-
-        if (options.retry_duration != consts.default_sse_retry_duration) {
-            try sse_msg.append(try std.fmt.allocPrint(self.allocator, "retry: {d}\n", .{options.retry_duration}));
-        }
-
-        for (data) |line| {
-            try sse_msg.append(try std.fmt.allocPrint(self.allocator, "data: {s}\n", .{line}));
-        }
-        try sse_msg.append("\n\n");
-
-        const encoded = try br.encode(self.allocator, try std.mem.concat(self.allocator, u8, sse_msg.items));
-        try self.writer.writeAll(encoded);
+    if (options.event_id) |id| {
+        try self.writer.print("id: {s}\n", .{id});
     }
+
+    if (options.retry_duration != consts.default_sse_retry_duration) {
+        try self.writer.print("retry: {d}\n", .{options.retry_duration});
+    }
+
+    for (data) |line| {
+        try self.writer.print("data: {s}\n", .{line});
+    }
+
+    try self.writer.writeAll("\n\n");
 }
 
 /// `ExecuteScript` executes JavaScript in the browser
@@ -192,14 +217,25 @@ pub fn executeScript(
         try data.append(line);
     }
 
-    try self.send(
-        .execute_script,
-        try data.toOwnedSlice(),
-        .{
-            .event_id = options.event_id,
-            .retry_duration = options.retry_duration,
-        },
-    );
+    if (self.encoding == .none) {
+        try self.send(
+            .execute_script,
+            try data.toOwnedSlice(),
+            .{
+                .event_id = options.event_id,
+                .retry_duration = options.retry_duration,
+            },
+        );
+    } else {
+        try self.prepareMsg(
+            .execute_script,
+            try data.toOwnedSlice(),
+            .{
+                .event_id = options.event_id,
+                .retry_duration = options.retry_duration,
+            },
+        );
+    }
 }
 
 /// `MergeFragments` merges one or more fragments into the DOM. By default,
@@ -280,14 +316,25 @@ pub fn mergeFragments(
         try data.append(line);
     }
 
-    try self.send(
-        .merge_fragments,
-        try data.toOwnedSlice(),
-        .{
-            .event_id = options.event_id,
-            .retry_duration = options.retry_duration,
-        },
-    );
+    if (self.encoding == .none) {
+        try self.send(
+            .merge_fragments,
+            try data.toOwnedSlice(),
+            .{
+                .event_id = options.event_id,
+                .retry_duration = options.retry_duration,
+            },
+        );
+    } else {
+        try self.prepareMsg(
+            .merge_fragments,
+            try data.toOwnedSlice(),
+            .{
+                .event_id = options.event_id,
+                .retry_duration = options.retry_duration,
+            },
+        );
+    }
 }
 
 /// `MergeSignals` sends one or more signals to the browser to be merged into the signals.
@@ -324,14 +371,25 @@ pub fn mergeSignals(
 
     try data.append(line);
 
-    try self.send(
-        .merge_signals,
-        try data.toOwnedSlice(),
-        .{
-            .event_id = options.event_id,
-            .retry_duration = options.retry_duration,
-        },
-    );
+    if (self.encoding == .none) {
+        try self.send(
+            .merge_signals,
+            try data.toOwnedSlice(),
+            .{
+                .event_id = options.event_id,
+                .retry_duration = options.retry_duration,
+            },
+        );
+    } else {
+        try self.prepareMsg(
+            .merge_signals,
+            try data.toOwnedSlice(),
+            .{
+                .event_id = options.event_id,
+                .retry_duration = options.retry_duration,
+            },
+        );
+    }
 }
 
 /// `RemoveFragments` sends a selector to the browser to remove HTML fragments from the DOM.
@@ -381,14 +439,25 @@ pub fn removeFragments(
 
     try data.append(line);
 
-    try self.send(
-        .remove_fragments,
-        try data.toOwnedSlice(),
-        .{
-            .event_id = options.event_id,
-            .retry_duration = options.retry_duration,
-        },
-    );
+    if (self.encoding == .none) {
+        try self.send(
+            .remove_fragments,
+            try data.toOwnedSlice(),
+            .{
+                .event_id = options.event_id,
+                .retry_duration = options.retry_duration,
+            },
+        );
+    } else {
+        try self.prepareMsg(
+            .remove_fragments,
+            try data.toOwnedSlice(),
+            .{
+                .event_id = options.event_id,
+                .retry_duration = options.retry_duration,
+            },
+        );
+    }
 }
 
 /// `RemoveSignals` sends signals to the browser to be removed from the signals.
@@ -414,12 +483,23 @@ pub fn removeSignals(
         try data.append(line);
     }
 
-    try self.send(
-        .remove_signals,
-        try data.toOwnedSlice(),
-        .{
-            .event_id = options.event_id,
-            .retry_duration = options.retry_duration,
-        },
-    );
+    if (self.encoding == .none) {
+        try self.send(
+            .remove_signals,
+            try data.toOwnedSlice(),
+            .{
+                .event_id = options.event_id,
+                .retry_duration = options.retry_duration,
+            },
+        );
+    } else {
+        try self.prepareMsg(
+            .remove_signals,
+            try data.toOwnedSlice(),
+            .{
+                .event_id = options.event_id,
+                .retry_duration = options.retry_duration,
+            },
+        );
+    }
 }

--- a/src/consts.zig
+++ b/src/consts.zig
@@ -3,7 +3,7 @@
 const std = @import("std");
 
 pub const datastar_key = "datastar";
-pub const version = "1.0.0-beta.3";
+pub const version = "1.0.0-beta.4";
 
 // #region Defaults
 

--- a/src/consts.zig
+++ b/src/consts.zig
@@ -3,7 +3,7 @@
 const std = @import("std");
 
 pub const datastar_key = "datastar";
-pub const version = "1.0.0-beta.4";
+pub const version = "1.0.0-beta.5";
 
 // #region Defaults
 

--- a/src/httpz/ServerSentEventGenerator.zig
+++ b/src/httpz/ServerSentEventGenerator.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+const config = @import("config");
+const httpz = @import("httpz");
+const ServerSentEventGenerator = @import("../ServerSentEventGenerator.zig");
+
+pub fn init(res: *httpz.Response) !ServerSentEventGenerator {
+    res.content_type = .EVENTS;
+    res.header("Cache-Control", "no-cache");
+
+    if (config.http1) {
+        res.header("Connection", "keep-alive");
+    }
+
+    try res.write();
+
+    const conn = res.conn;
+    conn.handover = .close;
+
+    return .{
+        .allocator = res.arena,
+        .writer = conn.stream.writer(),
+    };
+}

--- a/src/httpz/ServerSentEventGenerator.zig
+++ b/src/httpz/ServerSentEventGenerator.zig
@@ -3,9 +3,13 @@ const config = @import("config");
 const httpz = @import("httpz");
 const ServerSentEventGenerator = @import("../ServerSentEventGenerator.zig");
 
-pub fn init(res: *httpz.Response) !ServerSentEventGenerator {
+pub fn init(res: *httpz.Response, encoding: ServerSentEventGenerator.Encoding) !ServerSentEventGenerator {
     res.content_type = .EVENTS;
     res.header("Cache-Control", "no-cache");
+    switch (encoding) {
+        .none => {},
+        else => res.header("Content-Encoding", @tagName(encoding)),
+    }
 
     if (config.http1) {
         res.header("Connection", "keep-alive");
@@ -19,5 +23,6 @@ pub fn init(res: *httpz.Response) !ServerSentEventGenerator {
     return .{
         .allocator = res.arena,
         .writer = conn.stream.writer(),
+        .encoding = encoding,
     };
 }

--- a/src/httpz/ServerSentEventGenerator.zig
+++ b/src/httpz/ServerSentEventGenerator.zig
@@ -24,5 +24,6 @@ pub fn init(res: *httpz.Response, encoding: ServerSentEventGenerator.Encoding) !
         .allocator = res.arena,
         .writer = conn.stream.writer(),
         .encoding = encoding,
+        .sse_msg = std.ArrayList([]const u8).init(res.arena),
     };
 }

--- a/src/httpz/root.zig
+++ b/src/httpz/root.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+const httpz = @import("httpz");
+const consts = @import("../consts.zig");
+const testing = @import("../testing.zig");
+
+pub const ServerSentEventGenerator = @import("ServerSentEventGenerator.zig");
+
+/// `readSignals` is a helper function that reads datastar signals from the request.
+pub fn readSignals(comptime T: type, req: *httpz.Request) !T {
+    switch (req.method) {
+        .GET => {
+            const query = try req.query();
+            const signals = query.get(consts.datastar_key) orelse return error.MissingDatastarKey;
+
+            return std.json.parseFromSliceLeaky(T, req.arena, signals, .{});
+        },
+        else => {
+            const body = req.body() orelse return error.MissingBody;
+
+            return std.json.parseFromSliceLeaky(T, req.arena, body, .{});
+        },
+    }
+}
+
+fn sdk(req: *httpz.Request, res: *httpz.Response) !void {
+    var sse = try ServerSentEventGenerator.init(res);
+    const signals = try readSignals(
+        testing.Signals,
+        req,
+    );
+
+    try testing.sdk(&sse, signals);
+}
+
+test sdk {
+    var server = try httpz.Server(void).init(
+        std.testing.allocator,
+        .{ .port = 8080 },
+        {},
+    );
+    defer {
+        server.stop();
+        server.deinit();
+    }
+
+    var router = server.router(.{});
+
+    router.get("/test", sdk, .{});
+    router.post("/test", sdk, .{});
+
+    try server.listen();
+}

--- a/src/httpz/root.zig
+++ b/src/httpz/root.zig
@@ -23,7 +23,7 @@ pub fn readSignals(comptime T: type, req: *httpz.Request) !T {
 }
 
 fn sdk(req: *httpz.Request, res: *httpz.Response) !void {
-    var sse = try ServerSentEventGenerator.init(res);
+    var sse = try ServerSentEventGenerator.init(res, .none);
     const signals = try readSignals(
         testing.Signals,
         req,

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,4 +1,8 @@
 pub const consts = @import("consts.zig");
 pub const ServerSentEventGenerator = @import("ServerSentEventGenerator.zig");
+pub const httpz = @import("httpz/root.zig");
+pub const tk = @import("tokamak/root.zig");
 
-pub const testing = @import("testing.zig");
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/tokamak/ServerSentEventGenerator.zig
+++ b/src/tokamak/ServerSentEventGenerator.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+const config = @import("config");
+const tk = @import("tokamak");
+const ServerSentEventGenerator = @import("../ServerSentEventGenerator.zig");
+
+pub fn init(res: *tk.Response) !ServerSentEventGenerator {
+    res.content_type = .EVENTS;
+    res.header("Cache-Control", "no-cache");
+
+    if (config.http1) {
+        res.header("Connection", "keep-alive");
+    }
+
+    try res.write();
+
+    const conn = res.conn;
+    conn.handover = .close;
+
+    return .{
+        .allocator = res.arena,
+        .writer = conn.stream.writer(),
+    };
+}

--- a/src/tokamak/root.zig
+++ b/src/tokamak/root.zig
@@ -1,0 +1,45 @@
+const std = @import("std");
+const tk = @import("tokamak");
+const consts = @import("../consts.zig");
+const testing = @import("../testing.zig");
+
+pub const ServerSentEventGenerator = @import("ServerSentEventGenerator.zig");
+
+/// `readSignals` is a helper function that reads datastar signals from the request.
+pub fn readSignals(comptime T: type, req: *tk.Request) !T {
+    switch (req.method) {
+        .GET => {
+            const query = try req.query();
+            const signals = query.get(consts.datastar_key) orelse return error.MissingDatastarKey;
+
+            return std.json.parseFromSliceLeaky(T, req.arena, signals, .{});
+        },
+        else => {
+            const body = req.body() orelse return error.MissingBody;
+
+            return std.json.parseFromSliceLeaky(T, req.arena, body, .{});
+        },
+    }
+}
+
+fn sdk(req: *tk.Request, res: *tk.Response) !void {
+    var sse = try ServerSentEventGenerator.init(res);
+    const signals = try readSignals(
+        testing.Signals,
+        req,
+    );
+
+    try testing.sdk(&sse, signals);
+}
+
+const App = struct {
+    server: *tk.Server,
+    routes: []const tk.Route = &.{
+        .get("/test", sdk),
+        .post0("/test", sdk),
+    },
+};
+
+test sdk {
+    try tk.app.run(App);
+}

--- a/test_runner.zig
+++ b/test_runner.zig
@@ -35,14 +35,11 @@ pub fn main() !void {
     var skip: usize = 0;
     var leak: usize = 0;
 
-    try std.posix.getrandom(std.mem.asBytes(&std.testing.random_seed));
-
     const printer = Printer.init();
     printer.fmt("\r\x1b[0K", .{}); // beginning of line and clear to end of line
 
     for (builtin.test_functions) |t| {
         if (isSetup(t)) {
-            current_test = friendlyName(t.name);
             t.func() catch |err| {
                 printer.status(.fail, "\nsetup \"{s}\" failed: {}\n", .{ t.name, err });
                 return err;
@@ -65,15 +62,22 @@ pub fn main() !void {
             }
         }
 
-        const friendly_name = friendlyName(t.name);
+        const friendly_name = blk: {
+            const name = t.name;
+            var it = std.mem.splitScalar(u8, name, '.');
+            while (it.next()) |value| {
+                if (std.mem.eql(u8, value, "test")) {
+                    const rest = it.rest();
+                    break :blk if (rest.len > 0) rest else name;
+                }
+            }
+            break :blk name;
+        };
+
         current_test = friendly_name;
         std.testing.allocator_instance = .{};
         const result = t.func();
         current_test = null;
-
-        if (is_unnamed_test) {
-            continue;
-        }
 
         const ns_taken = slowest.endTiming(friendly_name);
 
@@ -112,7 +116,6 @@ pub fn main() !void {
 
     for (builtin.test_functions) |t| {
         if (isTeardown(t)) {
-            current_test = friendlyName(t.name);
             t.func() catch |err| {
                 printer.status(.fail, "\nteardown \"{s}\" failed: {}\n", .{ t.name, err });
                 return err;
@@ -133,17 +136,6 @@ pub fn main() !void {
     try slowest.display(printer);
     printer.fmt("\n", .{});
     std.posix.exit(if (fail == 0) 0 else 1);
-}
-
-fn friendlyName(name: []const u8) []const u8 {
-    var it = std.mem.splitScalar(u8, name, '.');
-    while (it.next()) |value| {
-        if (std.mem.eql(u8, value, "test")) {
-            const rest = it.rest();
-            return if (rest.len > 0) rest else name;
-        }
-    }
-    return name;
 }
 
 const Printer = struct {
@@ -292,12 +284,14 @@ const Env = struct {
     }
 };
 
-pub fn panic(msg: []const u8, error_return_trace: ?*std.builtin.StackTrace, ret_addr: ?usize) noreturn {
-    if (current_test) |ct| {
-        std.debug.print("\x1b[31m{s}\npanic running \"{s}\"\n{s}\x1b[0m\n", .{ BORDER, ct, BORDER });
+pub const panic = std.debug.FullPanic(struct {
+    pub fn panicFn(msg: []const u8, first_trace_addr: ?usize) noreturn {
+        if (current_test) |ct| {
+            std.debug.print("\x1b[31m{s}\npanic running \"{s}\"\n{s}\x1b[0m\n", .{ BORDER, ct, BORDER });
+        }
+        std.debug.defaultPanic(msg, first_trace_addr);
     }
-    std.debug.defaultPanic(msg, error_return_trace, ret_addr);
-}
+}.panicFn);
 
 fn isUnnamed(t: std.builtin.TestFn) bool {
     const marker = ".test_";


### PR DESCRIPTION
Hi, I heard on the latest Datastar podcast between Delaney and Ben on youtube, that the people in charge on the clojure sdk were working on adding encoding capabilities to their sdk.

I too wanted to add the option to use brotli to the zig sdk and did this proof of concept as food for though. I also added the gzip encoding while I was at it.

Since you can not encode the mergeFragments/Signals individually, the whole final response needs to be encoded before being sent back to the browser as 1 big chunk. This disqualify long lasting sse connections, but it might still be interesting when you know that you will be sending a big fragment of data for some specific requests . My current workaround is to use a new "pub fn sendMsg()" after all the mergeFragments/Signals calls (only when encoding ".br" or ".gzip" is chosen, not if the encoding is ".none"), resulting in this code:
```zig
const ds = @import("datastar");
const dsz = ds.httpz;

// with encoding:
var sse = try dsz.ServerSentEventGenerator.init(res, .br); // or ".gzip"
try sse.mergeFragments(big_fragment, .{ .selector = "#overlay", .merge_mode = .inner });
try sse.mergeSignals("{_show_overlay: true}", .{});
try sse.sendMsg();

// without encoding, normal behavior:
var sse = try dsz.ServerSentEventGenerator.init(res, .none);
try sse.mergeFragments(big_fragment, .{ .selector = "#overlay", .merge_mode = .inner });
try sse.mergeSignals("{_show_overlay: true}", .{});
```

Again, this is just a proof of concept hastily put together this weekend, to start a possible discussion concerning the usefulness of adding brotli/gzip/etc.. encoding capabilites to the zig sdk. Especially since it has been pointed out that nginx can automatically do it for you anyway.